### PR TITLE
Apple Silicon でもビルドできるよう修正し README にも追記.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM --platform=linux/amd64 ubuntu:24.04
 
 ENV OS_LOCALE="en_US.UTF-8" \
     LANG=${OS_LOCALE} \

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ $ cd /birds
 
 ### How to build
 
+CPU が Apple silicon の場合は、 Docker のオプションで `Use Rosetta for x86_64/amd64 emulation on Apple Silicon` を無効にしてください（ Rosetta が有効だとビルドが失敗します）。
+
 ```bash
 $ docker build -t vebirds .
 ```


### PR DESCRIPTION
Apple Silicon CPU だとビルドに失敗してしまう場合があるので設定を追加し、 Docker 側に必要な設定なども README.md に追記。